### PR TITLE
Fix the issue that the aic8800-sdio cannot be used in kernel 6.5.0 or…

### DIFF
--- a/debian/patches/fix-linux-6.5-build.patch
+++ b/debian/patches/fix-linux-6.5-build.patch
@@ -1,0 +1,14 @@
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+index dc8bc5a..0c81123 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -5512,6 +5512,9 @@ rwnx_cfg80211_tdls_mgmt(struct wiphy *wiphy,
+ 	const u8 *peer,
+ #else
+ 	u8 *peer,
++#endif
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0))
++	int link_id,
+ #endif
+ 	u8 action_code,
+ 	u8 dialog_token,

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@ fix-usb-firmware-path.patch
 fix-linux-6.1-build.patch
 fix-aic_btusb.patch
 fix-linux-6.7-build.patch
+fix-linux-6.5-build.patch


### PR DESCRIPTION
Fix the issue that the aic8800-sdio cannot be used in kernel 6.5.0 or later
Signed-off-by: Peiyu Wu <wupeiyu@radxa.com>
