### PR TITLE
Update aicwf_wext_linux.c

### DIFF
--- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_wext_linux.c
+++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_wext_linux.c
@@ -616,7 +616,6 @@ static inline char *aicwf_get_iwe_stream_rate(struct rwnx_hw* rwnx_hw,
 	u16 vht_data_rate = 0;
 
 	u16 he_cap = false;
-	u8 he_ch_width_set = 0;
 	u8 he_bw = 0;
 
 	/* parsing HT_CAP_IE	 */


### PR DESCRIPTION
Remove unused variable in line 619 because of build failing due to 'warning: unused variable'.