### PR TITLE
fix build for kernel after 6.1.107

### DIFF
--- a/debian/patches/fix-linux-6.7-build.patch
+++ b/debian/patches/fix-linux-6.7-build.patch
@@ -52,7 +52,7 @@ diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c b/src/USB/
 index 41a1e13..3f7a0cf 100644
 --- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
 +++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
-@@ -464,8 +464,18 @@ static bool rwnx_rx_data_skb(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rwnx_vif,
+@@ -464,8 +464,21 @@ static bool rwnx_rx_data_skb(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rwnx_vif,
  
      if (amsdu) {
          int count;
@@ -64,6 +64,9 @@ index 41a1e13..3f7a0cf 100644
 +        ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
 +                                 RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, false);
 +#endif
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 107) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0))
++        ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
++                                 RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, false);
 +#else
          ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
                                   RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL);
@@ -191,7 +194,7 @@ diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c b/src/PCIE
 index 158c18b..bfd7429 100644
 --- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
 +++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
-@@ -453,8 +453,18 @@ static bool rwnx_rx_data_skb(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rwnx_vif,
+@@ -453,8 +453,21 @@ static bool rwnx_rx_data_skb(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rwnx_vif,
  
  	if (amsdu) {
  		int count;
@@ -203,6 +206,9 @@ index 158c18b..bfd7429 100644
 +		ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
 +								RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, false);
 +#endif
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 107) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0))
++		ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
++								 RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, false);
 +#else
  		ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
  								 RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL);


### PR DESCRIPTION
https://github.com/torvalds/linux/commit/986e43b19ae9176093da35e0a844e65c8bf9ede7 is backported to 6.1.107, this adds fix for it.