### PR TITLE
fix build with gcc14

### DIFF
--- a/debian/patches/fix-linux-6.7-build.patch
+++ b/debian/patches/fix-linux-6.7-build.patch
@@ -59,7 +59,7 @@ index 41a1e13..3f7a0cf 100644
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
 +        ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
-+                                 RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, NULL);
++                                 RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, 0);
 +#else
 +        ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
 +                                 RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, false);
@@ -201,7 +201,7 @@ index 158c18b..bfd7429 100644
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
 +		ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
-+								 RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, NULL);
++								 RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, 0);
 +#else
 +		ieee80211_amsdu_to_8023s(skb, &list, rwnx_vif->ndev->dev_addr,
 +								RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, false);


### PR DESCRIPTION
Error:
/usr/src/linux-headers-6.12.25-common/include/linux/stddef.h:8:14: error: passing argument 8 of ‘ieee80211_amsdu_to_8023s’ makes integer from pointer without a cast [-Wint-conversion]
    8 | #define NULL ((void *)0)
      |              ^~~~~~~~~~~
      |              |
      |              void *
/var/lib/dkms/aic8800-pcie/3.0+git20240327.3561b08f-5/build/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c:459:106: note: in expansion of macro ‘NULL’
  459 |                                                                  RWNX_VIF_TYPE(rwnx_vif), 0, NULL, NULL, NULL);
      |                                                                                                          ^~~~

We have to use 0 instead of NULL.