### PR TITLE
fix build for linux 6.16

### DIFF
--- a/.github/workflows/check_linked_issue.yaml
+++ b/.github/workflows/check_linked_issue.yaml
@@ -13,5 +13,6 @@ name: "Check linked issues"
   pull_request_target:
     types:
     - "opened"
+    - "edited"
     - "reopened"
 permissions: {}

--- a/debian/patches/fix-linux-6.13-build.patch
+++ b/debian/patches/fix-linux-6.13-build.patch
@@ -20,7 +20,7 @@ diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/PC
 index fc58409..08d41ad 100644
 --- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
 +++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -5042,6 +5042,9 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
+@@ -3326,6 +3326,9 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
   * configured at firmware level.
   */
  static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
@@ -30,6 +30,18 @@ index fc58409..08d41ad 100644
  											 struct cfg80211_chan_def *chandef)
  {
  	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+@@ -3380,7 +3380,11 @@ static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
+ 
+ int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
+                                              struct cfg80211_chan_def *chandef){
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 13, 0)
++    return rwnx_cfg80211_set_monitor_channel(wiphy, NULL, chandef);
++#else
+     return rwnx_cfg80211_set_monitor_channel(wiphy, chandef);
++#endif
+ }
+ 
+ /**
 @@ -5484,7 +5487,11 @@ static int rwnx_cfg80211_get_channel(struct wiphy *wiphy,
  
  	if (rwnx_vif->vif_index == rwnx_hw->monitor_vif) {
@@ -63,7 +75,7 @@ diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/SD
 index 86567f9..a4c760d 100644
 --- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
 +++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -4833,6 +4833,9 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
+@@ -3326,6 +3326,9 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
   * configured at firmware level.
   */
  static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
@@ -73,6 +85,18 @@ index 86567f9..a4c760d 100644
  											 struct cfg80211_chan_def *chandef)
  {
  	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+@@ -3481,7 +3481,11 @@ static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
+ 
+ int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
+                                              struct cfg80211_chan_def *chandef){
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 13, 0)
++    return rwnx_cfg80211_set_monitor_channel(wiphy, NULL, chandef);
++#else
+     return rwnx_cfg80211_set_monitor_channel(wiphy, chandef);
++#endif
+ }
+ 
+ 
 @@ -5281,7 +5284,11 @@ static int rwnx_cfg80211_get_channel(struct wiphy *wiphy,
  
  	if (rwnx_vif->vif_index == rwnx_hw->monitor_vif) {
@@ -119,7 +143,7 @@ diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c b/src/US
 index 2c337d8..1266da0 100644
 --- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
 +++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -5186,6 +5186,9 @@ cfg80211_chandef_identical(const struct cfg80211_chan_def *chandef1,
+@@ -3326,6 +3326,9 @@ cfg80211_chandef_identical(const struct cfg80211_chan_def *chandef1,
  #endif
  
  static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
@@ -129,6 +153,18 @@ index 2c337d8..1266da0 100644
                                               struct cfg80211_chan_def *chandef)
  {
      struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+@@ -3899,7 +3899,11 @@ static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
+ 
+ int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
+                                              struct cfg80211_chan_def *chandef){
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 13, 0)
++    return rwnx_cfg80211_set_monitor_channel(wiphy, NULL, chandef);
++#else
+     return rwnx_cfg80211_set_monitor_channel(wiphy, chandef);
++#endif
+ }
+ 
+ 
 @@ -5711,7 +5714,11 @@ static int rwnx_cfg80211_get_channel(struct wiphy *wiphy,
      if (rwnx_vif->vif_index == rwnx_hw->monitor_vif)
      {

--- a/debian/patches/fix-linux-6.14-build.patch
+++ b/debian/patches/fix-linux-6.14-build.patch
@@ -1,0 +1,28 @@
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+index 3ee11ae..77efdc8 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3582,6 +3582,9 @@ static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *
+ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+  struct wireless_dev *wdev,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 14, 0)
++ unsigned int link_id,
++#endif
+ #endif
+ 	int *mbm)
+ {
+diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+index f808d88..4b6aa20 100644
+--- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3480,6 +3480,9 @@ static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *
+ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+  struct wireless_dev *wdev,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 14, 0)
++ unsigned int link_id,
++#endif
+ #endif
+ 	int *mbm)
+ {

--- a/debian/patches/fix-linux-6.15-build.patch
+++ b/debian/patches/fix-linux-6.15-build.patch
@@ -206,6 +206,18 @@ index 2c337d8..171b171 100644
  		}
  		if (rwnx_vif->up) {
  			rwnx_send_remove_if(rwnx_hw, rwnx_vif->vif_index, true);
+@@ -8485,7 +8485,11 @@ void rwnx_cfg80211_deinit(struct rwnx_hw *rwnx_hw)
+         list_for_each_entry(defrag_ctrl, &rwnx_hw->defrag_list, list) {
+             list_del_init(&defrag_ctrl->list);
+             if (timer_pending(&defrag_ctrl->defrag_timer))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++                timer_delete_sync(&defrag_ctrl->defrag_timer);
++#else
+                 del_timer_sync(&defrag_ctrl->defrag_timer);
++#endif
+             dev_kfree_skb(defrag_ctrl->skb);
+             kfree(defrag_ctrl);
+         }
 diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
 index bbf21c9..79b5fc2 100644
 --- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
@@ -246,3 +258,171 @@ index bbf21c9..79b5fc2 100644
  		}
      }
  
+@@ -2386,7 +2386,11 @@ check_len_update:
+ 							skb_tmp = defrag_info->skb;
+ 							list_del_init(&defrag_info->list);
+ 							if (timer_pending(&defrag_info->defrag_timer)) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++								ret = timer_delete(&defrag_info->defrag_timer);
++#else
+ 								ret = del_timer(&defrag_info->defrag_timer);
++#endif
+ 							}
+ 							kfree(defrag_info);
+ 							spin_unlock_bh(&rwnx_hw->defrag_lock);
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_tcp_ack.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
+index ca47b26..d74bd8d 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
+@@ -106,7 +106,11 @@ void tcp_ack_deinit(struct rwnx_hw *priv)
+ 		drop_msg = NULL;
+ 
+ 		write_seqlock_bh(&ack_m->ack_info[i].seqlock);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		timer_delete(&ack_m->ack_info[i].timer);
++#else
+ 		del_timer(&ack_m->ack_info[i].timer);
++#endif
+ 		drop_msg = ack_m->ack_info[i].msgbuf;
+ 		ack_m->ack_info[i].msgbuf = NULL;
+ 		write_sequnlock_bh(&ack_m->ack_info[i].seqlock);
+@@ -375,7 +379,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				//printk("%lx \n",ack_info->msgbuf);
+ 				drop_msg = ack_info->msgbuf;
+ 				ack_info->msgbuf = NULL;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++				timer_delete(&ack_info->timer);
++#else
+ 				del_timer(&ack_info->timer);
++#endif
+ 			}else{
+ 				//printk("msgbuf is NULL \n");
+ 			}
+@@ -409,7 +417,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				   atomic_read(&ack_m->max_drop_cnt)))) {
+ 			ack_info->drop_cnt = 0;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		} else {
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;
+@@ -472,7 +484,11 @@ int tcp_ack_handle_new(struct msg_buf *new_msgbuf,
+ 			ack_info->drop_cnt = 0;
+ 			//send_msg = new_msgbuf;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		}else{
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;
+diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_tcp_ack.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
+index 4ee7e64..cfec217 100644
+--- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
++++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
+@@ -115,7 +115,11 @@ void tcp_ack_deinit(struct rwnx_hw *priv)
+ 		drop_msg = NULL;
+ 
+ 		write_seqlock_bh(&ack_m->ack_info[i].seqlock);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		timer_delete(&ack_m->ack_info[i].timer);
++#else
+ 		del_timer(&ack_m->ack_info[i].timer);
++#endif
+ 		drop_msg = ack_m->ack_info[i].msgbuf;
+ 		ack_m->ack_info[i].msgbuf = NULL;
+ 		write_sequnlock_bh(&ack_m->ack_info[i].seqlock);
+@@ -388,7 +392,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				//printk("%lx \n",ack_info->msgbuf);
+ 				drop_msg = ack_info->msgbuf;
+ 				ack_info->msgbuf = NULL;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++				timer_delete(&ack_info->timer);
++#else
+ 				del_timer(&ack_info->timer);
++#endif
+ 			}else{
+ 				//printk("msgbuf is NULL \n");
+ 			}
+@@ -422,7 +430,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				   atomic_read(&ack_m->max_drop_cnt)))) {
+ 			ack_info->drop_cnt = 0;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		} else {
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;
+@@ -486,7 +498,11 @@ int tcp_ack_handle_new(struct msg_buf *new_msgbuf,
+ 			ack_info->drop_cnt = 0;
+ 			//send_msg = new_msgbuf;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 			if(drop_msg) {
+ 			write_seqlock_bh(&rwnx_hw->txdata_reserved_seqlock);
+ 			rwnx_hw->txdata_reserved--;
+diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
+index 480fd07..47f0598 100644
+--- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
++++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
+@@ -106,7 +106,11 @@ void tcp_ack_deinit(struct rwnx_hw *priv)
+ 		drop_msg = NULL;
+ 
+ 		write_seqlock_bh(&ack_m->ack_info[i].seqlock);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		timer_delete(&ack_m->ack_info[i].timer);
++#else
+ 		del_timer(&ack_m->ack_info[i].timer);
++#endif
+ 		drop_msg = ack_m->ack_info[i].msgbuf;
+ 		ack_m->ack_info[i].msgbuf = NULL;
+ 		write_sequnlock_bh(&ack_m->ack_info[i].seqlock);
+@@ -375,7 +379,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				//printk("%lx \n",ack_info->msgbuf);
+ 				drop_msg = ack_info->msgbuf;
+ 				ack_info->msgbuf = NULL;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++				timer_delete(&ack_info->timer);
++#else
+ 				del_timer(&ack_info->timer);
++#endif
+ 			}else{
+ 				//printk("msgbuf is NULL \n");
+ 			}
+@@ -409,7 +417,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				   atomic_read(&ack_m->max_drop_cnt)))) {
+ 			ack_info->drop_cnt = 0;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		} else {
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;
+@@ -472,7 +484,11 @@ int tcp_ack_handle_new(struct msg_buf *new_msgbuf,
+ 			ack_info->drop_cnt = 0;
+ 			//send_msg = new_msgbuf;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		}else{
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;

--- a/debian/patches/fix-linux-6.16-build.patch
+++ b/debian/patches/fix-linux-6.16-build.patch
@@ -1,0 +1,233 @@
+diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+index 7c5d9e0..58b6db1 100644
+--- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3414,7 +3414,11 @@ void aicwf_p2p_alive_timeout(struct timer_list *t)
+ 	rwnx_vif = (struct rwnx_vif *)data;
+ 	rwnx_hw = rwnx_vif->rwnx_hw;
+ 	#else
++	#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	rwnx_hw = timer_container_of(rwnx_hw, t, p2p_alive_timer);
++	#else
+ 	rwnx_hw = from_timer(rwnx_hw, t, p2p_alive_timer);
++	#endif
+ 	rwnx_vif = rwnx_hw->p2p_dev_vif;
+ 	#endif
+ 
+diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
+index 158c18b..14e3bda 100644
+--- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
++++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
+@@ -1981,9 +1981,13 @@ void reord_timeout_handler (struct timer_list *t)
+ {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+ 	struct reord_ctrl *preorder_ctrl = (struct reord_ctrl *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct reord_ctrl *preorder_ctrl = timer_container_of(preorder_ctrl, t, reord_timer);
+ #else
+ 	struct reord_ctrl *preorder_ctrl = from_timer(preorder_ctrl, t, reord_timer);
+ #endif
++#endif
+ 
+ #if 0
+ 	struct aicwf_rx_priv *rx_priv = preorder_ctrl->rx_priv;
+@@ -2227,8 +2231,12 @@ void defrag_timeout_cb(struct timer_list *t)
+ 	struct defrag_ctrl_info *defrag_ctrl = NULL;
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+ 	defrag_ctrl = (struct defrag_ctrl_info *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	defrag_ctrl = timer_container_of(defrag_ctrl, t, defrag_timer);
+ #else
+ 	defrag_ctrl = from_timer(defrag_ctrl, t, defrag_timer);
++#endif
+ #endif
+ 
+ 	printk("%s:%p\r\n", __func__, defrag_ctrl);
+diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+index 2c337d8..4d9ef8a 100644
+--- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
++++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3304,7 +3304,11 @@ void aicwf_p2p_alive_timeout(struct timer_list *t)
+     rwnx_vif = (struct rwnx_vif *)data;
+     rwnx_hw = rwnx_vif->rwnx_hw;
+     #else
++    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++    rwnx_hw = timer_container_of(rwnx_hw, t, p2p_alive_timer);
++    #else
+     rwnx_hw = from_timer(rwnx_hw, t, p2p_alive_timer);
++    #endif
+     rwnx_vif = rwnx_hw->p2p_dev_vif;
+     #endif
+ 
+diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
+index bbf21c9..22bb9cf 100644
+--- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
++++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
+@@ -1658,8 +1658,12 @@ void reord_timeout_handler (struct timer_list *t)
+ {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
+ 	struct reord_ctrl *preorder_ctrl = (struct reord_ctrl *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct reord_ctrl *preorder_ctrl = timer_container_of(preorder_ctrl, t, reord_timer);
+ #else
+ 	struct reord_ctrl *preorder_ctrl = from_timer(preorder_ctrl, t, reord_timer);
++#endif
+ #endif
+ 
+ 	AICWFDBG(LOGTRACE, "%s Enter \r\n", __func__);
+@@ -2024,8 +2028,12 @@ void defrag_timeout_cb(struct timer_list *t)
+ 	struct defrag_ctrl_info *defrag_ctrl = NULL;
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+ 	defrag_ctrl = (struct defrag_ctrl_info *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	defrag_ctrl = timer_container_of(defrag_ctrl, t, defrag_timer);
+ #else
+ 	defrag_ctrl = from_timer(defrag_ctrl, t, defrag_timer);
++#endif
+ #endif
+ 
+ 	printk("%s:%p\r\n", __func__, defrag_ctrl);
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.c
+index 4a9707c..a3d0fd9 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.c
+@@ -1370,7 +1370,11 @@ int aicwf_sdio_busrx_thread(void *data)
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+ static void aicwf_sdio_bus_pwrctl(struct timer_list *t)
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct aic_sdio_dev *sdiodev = timer_container_of(sdiodev, t, timer);
++#else
+ 	struct aic_sdio_dev *sdiodev = from_timer(sdiodev, t, timer);
++#endif
+ #else
+ static void aicwf_sdio_bus_pwrctl(ulong data)
+ {
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+index 86567f9..1bfee66 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3097,7 +3097,11 @@ void aicwf_p2p_alive_timeout(struct timer_list *t)
+ 	rwnx_vif = (struct rwnx_vif *)data;
+ 	rwnx_hw = rwnx_vif->rwnx_hw;
+ 	#else
++	#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	rwnx_hw = timer_container_of(rwnx_hw, t, p2p_alive_timer);
++	#else
+ 	rwnx_hw = from_timer(rwnx_hw, t, p2p_alive_timer);
++	#endif
+ 	rwnx_vif = rwnx_hw->p2p_dev_vif;
+ 	#endif
+ 
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
+index d740f14..86960af 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
+@@ -1657,9 +1657,13 @@ void reord_timeout_handler (struct timer_list *t)
+ {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+ 	struct reord_ctrl *preorder_ctrl = (struct reord_ctrl *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct reord_ctrl *preorder_ctrl = timer_container_of(preorder_ctrl, t, reord_timer);
+ #else
+ 	struct reord_ctrl *preorder_ctrl = from_timer(preorder_ctrl, t, reord_timer);
+ #endif
++#endif
+ 
+ #if 0 //AIDEN
+ 	struct aicwf_rx_priv *rx_priv = preorder_ctrl->rx_priv;
+@@ -1907,8 +1911,12 @@ void defrag_timeout_cb(struct timer_list *t)
+ 	struct defrag_ctrl_info *defrag_ctrl = NULL;
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+ 	defrag_ctrl = (struct defrag_ctrl_info *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	defrag_ctrl = timer_container_of(defrag_ctrl, t, defrag_timer);
+ #else
+ 	defrag_ctrl = from_timer(defrag_ctrl, t, defrag_timer);
++#endif
+ #endif
+ 
+ 	printk("%s:%p\r\n", __func__, defrag_ctrl);
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_wakelock.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_wakelock.c
+index 69bcf3f..b6c8219 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_wakelock.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_wakelock.c
+@@ -11,10 +11,14 @@
+ 
+ struct wakeup_source *rwnx_wakeup_init(const char *name)
+ {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ 	struct wakeup_source *ws;
+ 	ws = wakeup_source_create(name);
+ 	wakeup_source_add(ws);
+ 	return ws;
++#else
++	return NULL;
++#endif
+ }
+ 
+ void rwnx_wakeup_deinit(struct wakeup_source *ws)
+@@ -21,8 +23,10 @@ void rwnx_wakeup_deinit(struct wakeup_source *ws)
+ {
+ 	if (ws && ws->active)
+ 		__pm_relax(ws);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ 	wakeup_source_remove(ws);
+ 	wakeup_source_destroy(ws);
++#endif
+ }
+ 
+ struct wakeup_source *rwnx_wakeup_register(struct device *dev, const char *name)
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_sdio.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_sdio.c
+index 3ab130a..6a936ca 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_sdio.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_sdio.c
+@@ -1952,8 +1952,12 @@ static void aicwf_sdio_bus_pwrctl(struct timer_list *t)
+ {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+ 	struct aic_sdio_dev *sdiodev = (struct aic_sdio_dev *) data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct aic_sdio_dev *sdiodev = timer_container_of(sdiodev, t, timer);
+ #else
+ 	struct aic_sdio_dev *sdiodev = from_timer(sdiodev, t, timer);
++#endif
+ #endif
+ 
+ 	if (sdiodev->bus_if->state == BUS_DOWN_ST) {
+diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_wakelock.c b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_wakelock.c
+index 90e7ad8..9e96057 100644
+--- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_wakelock.c
++++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_wakelock.c
+@@ -11,10 +11,14 @@
+ 
+ struct wakeup_source *rwnx_wakeup_init(const char *name)
+ {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ 	struct wakeup_source *ws;
+ 	ws = wakeup_source_create(name);
+ 	wakeup_source_add(ws);
+ 	return ws;
++#else
++	return NULL;
++#endif
+ }
+ 
+ void rwnx_wakeup_deinit(struct wakeup_source *ws)
+@@ -21,8 +23,10 @@ void rwnx_wakeup_deinit(struct wakeup_source *ws)
+ {
+ 	if (ws && ws->active)
+ 		__pm_relax(ws);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ 	wakeup_source_remove(ws);
+ 	wakeup_source_destroy(ws);
++#endif
+ }
+ 
+ struct wakeup_source *rwnx_wakeup_register(struct device *dev, const char *name)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -11,6 +11,8 @@ fix-linux-6.5-build.patch
 fix-linux-6.9-build.patch
 fix-linux-6.12-build.patch
 fix-linux-6.13-build.patch
+fix-linux-6.14-build.patch
 fix-linux-6.15-build.patch
 fix-aic_btusb-implicit-declare-compat_ptr.patch
 fix-allwinner-dkms.patch
+fix-linux-6.16-build.patch


### PR DESCRIPTION
Fixes #41.
The new driver release has also introduced code need patches for kernel api change in 6.13, 6.14 and 6.15, I have fixed them all.