### PR TITLE
fix: recompress modules for kmod >= 31 and dkms < 3.2.0

### DIFF
--- a/debian/aic8800-pcie-dkms.dkms
+++ b/debian/aic8800-pcie-dkms.dkms
@@ -9,4 +9,6 @@ DEST_MODULE_NAME[0]="${BUILT_MODULE_NAME[0]}_$PACKAGE_VARIANT"
 BUILT_MODULE_LOCATION[0]="PCIE/driver_fw/driver/aic8800/aic8800_fdrv"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
 
+POST_BUILD[0]="scripts/recompress-modules.sh"
+
 AUTOINSTALL=yes

--- a/debian/aic8800-pcie-dkms.install
+++ b/debian/aic8800-pcie-dkms.install
@@ -1,3 +1,4 @@
 #!/usr/bin/dh-exec
 
 src/PCIE usr/src/aic8800-pcie-${DEB_VERSION}/
+src/scripts usr/src/aic8800-pcie-${DEB_VERSION}/

--- a/debian/aic8800-sdio-dkms.dkms
+++ b/debian/aic8800-sdio-dkms.dkms
@@ -19,4 +19,6 @@ DEST_MODULE_NAME[2]="${BUILT_MODULE_NAME[2]}_$PACKAGE_VARIANT"
 BUILT_MODULE_LOCATION[2]="SDIO/driver_fw/driver/aic8800/${BUILT_MODULE_NAME[2]}"
 DEST_MODULE_LOCATION[2]="/updates/dkms"
 
+POST_BUILD[0]="scripts/recompress-modules.sh"
+
 AUTOINSTALL=yes

--- a/debian/aic8800-sdio-dkms.install
+++ b/debian/aic8800-sdio-dkms.install
@@ -1,3 +1,4 @@
 #!/usr/bin/dh-exec
 
 src/SDIO usr/src/aic8800-sdio-${DEB_VERSION}/
+src/scripts usr/src/aic8800-sdio-${DEB_VERSION}/

--- a/debian/aic8800-usb-dkms.dkms
+++ b/debian/aic8800-usb-dkms.dkms
@@ -20,4 +20,6 @@ DEST_MODULE_NAME[2]="${BUILT_MODULE_NAME[2]}_$PACKAGE_VARIANT"
 BUILT_MODULE_LOCATION[2]="USB/driver_fw/drivers/aic_btusb"
 DEST_MODULE_LOCATION[2]="/updates/dkms"
 
+POST_BUILD[0]="scripts/recompress-modules.sh"
+
 AUTOINSTALL=yes

--- a/debian/aic8800-usb-dkms.install
+++ b/debian/aic8800-usb-dkms.install
@@ -1,3 +1,4 @@
 #!/usr/bin/dh-exec
 
 src/USB usr/src/aic8800-usb-${DEB_VERSION}/
+src/scripts usr/src/aic8800-usb-${DEB_VERSION}/

--- a/src/scripts/recompress-modules.sh
+++ b/src/scripts/recompress-modules.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# fix: https://bugs.gentoo.org/920837
+
+KMOD_ISSUE_VERSION="31"
+DKMS_ISSUE_VERSION="3.2.0"
+MODULE_DKMS_DIR="/var/lib/dkms/$module/$module_version/$(uname -r)/$(uname -p)/module"
+
+kmod_version=$(kmod --version | head -n 1 | awk '{print $3}')
+dkms_version=$(dkms --version | awk -F'-' '{print $2}')
+
+if [ "$(printf '%s\n' $DKMS_ISSUE_VERSION $dkms_version | sort -rV | head -n1)" != "$dkms_version" ] && [ "$kmod_version" -ge "$KMOD_ISSUE_VERSION" ] ; then
+    find "$MODULE_DKMS_DIR" -name "*.ko.xz" -print0 | while IFS= read -r -d '' module_file; do
+        /usr/bin/xz -d ${module_file}
+        /usr/bin/xz --check=crc32 --lzma2=dict=1MiB -f ${module_file%.xz}
+    done
+fi


### PR DESCRIPTION
DKMS: https://bugs.gentoo.org/920837