### PR TITLE
fix: update patchset

### DIFF
--- a/debian/patches/fix-Lower-the-debugging-log-level.patch
+++ b/debian/patches/fix-Lower-the-debugging-log-level.patch
@@ -13,10 +13,10 @@ Signed-off-by: Feng Zhang <feng@radxa.com>
  5 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-index f5fc2f8..a421ac9 100644
+index b757b7e..ece06fe 100644
 --- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
 +++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -512,7 +512,7 @@ static const int rwnx_hwq2uapsd[NL80211_NUM_ACS] = {
+@@ -530,7 +530,7 @@ static const int rwnx_hwq2uapsd[NL80211_NUM_ACS] = {
  #endif
  
  extern uint8_t scanning;
@@ -26,7 +26,7 @@ index f5fc2f8..a421ac9 100644
  #ifdef CONFIG_DYNAMIC_PWR
  int dynamic_pwr = 1;
 diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_main.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_main.c
-index 062944f..4067819 100644
+index 653a021..9a36d28 100644
 --- a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_main.c
 +++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_main.c
 @@ -15,7 +15,7 @@
@@ -39,10 +39,10 @@ index 062944f..4067819 100644
  struct semaphore aicbsp_probe_semaphore;
  
 diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-index 7136456..d20167b 100644
+index f330e38..9dda0d8 100644
 --- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
 +++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -512,7 +512,7 @@ static const int rwnx_hwq2uapsd[NL80211_NUM_ACS] = {
+@@ -535,7 +535,7 @@ static const int rwnx_hwq2uapsd[NL80211_NUM_ACS] = {
  
  
  extern uint8_t scanning;
@@ -52,10 +52,10 @@ index 7136456..d20167b 100644
  #ifdef CONFIG_DYNAMIC_PWR
  int dynamic_pwr = 1;
 diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
-index ae0e4df..c5cbb91 100644
+index 06d6096..972b731 100644
 --- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
 +++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -536,7 +536,7 @@ static const int rwnx_hwq2uapsd[NL80211_NUM_ACS] = {
+@@ -548,7 +548,7 @@ static const int rwnx_hwq2uapsd[NL80211_NUM_ACS] = {
  struct semaphore aicwf_deinit_sem;
  atomic_t aicwf_deinit_atomic;
  
@@ -65,7 +65,7 @@ index ae0e4df..c5cbb91 100644
  #ifdef CONFIG_DYNAMIC_PWR
  int dynamic_pwr = 1;
 diff --git a/src/USB/driver_fw/drivers/aic8800/aic_load_fw/aic_bluetooth_main.c b/src/USB/driver_fw/drivers/aic8800/aic_load_fw/aic_bluetooth_main.c
-index be05052..69f23f0 100644
+index 54fde6c..bf3dd49 100644
 --- a/src/USB/driver_fw/drivers/aic8800/aic_load_fw/aic_bluetooth_main.c
 +++ b/src/USB/driver_fw/drivers/aic8800/aic_load_fw/aic_bluetooth_main.c
 @@ -20,7 +20,7 @@ int adap_test = 0;
@@ -77,6 +77,3 @@ index be05052..69f23f0 100644
  int flash_erase_len = 0x400000;
  uint32_t ad_data_filter_mask = 0;
  uint32_t gpio_num = 2;//default select gpiob2 for fw_wakeup_host
--- 
-2.49.0
-

--- a/debian/patches/fix-linux-6.13-build.patch
+++ b/debian/patches/fix-linux-6.13-build.patch
@@ -16,11 +16,11 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c | 7 +++++++
  1 file changed, 7 insertions(+)
 
-diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-index fc58409..08d41ad 100644
---- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-+++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -3326,6 +3326,9 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
+Index: aic8800/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+===================================================================
+--- aic8800.orig/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ aic8800/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3684,6 +3684,9 @@ static int rwnx_cfg80211_stop_ap(struct
   * configured at firmware level.
   */
  static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
@@ -30,7 +30,7 @@ index fc58409..08d41ad 100644
  											 struct cfg80211_chan_def *chandef)
  {
  	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
-@@ -3380,7 +3380,11 @@ static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
+@@ -3738,7 +3741,11 @@ static int rwnx_cfg80211_set_monitor_cha
  
  int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
                                               struct cfg80211_chan_def *chandef){
@@ -42,7 +42,7 @@ index fc58409..08d41ad 100644
  }
  
  /**
-@@ -5484,7 +5487,11 @@ static int rwnx_cfg80211_get_channel(struct wiphy *wiphy,
+@@ -4149,7 +4156,11 @@ static int rwnx_cfg80211_get_channel(str
  
  	if (rwnx_vif->vif_index == rwnx_hw->monitor_vif) {
  		//retrieve channel from firmware
@@ -54,11 +54,11 @@ index fc58409..08d41ad 100644
  	}
  
  	//Check if channel context is valid
-diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c
-index 5d7e6bb..478b556 100644
---- a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c
-+++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c
-@@ -468,8 +468,12 @@ void rwnx_rx_handle_msg(struct aic_sdio_dev *sdiodev, struct ipc_e2a_msg *msg)
+Index: aic8800/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c
+===================================================================
+--- aic8800.orig/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c
++++ aic8800/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c
+@@ -476,8 +476,12 @@ void rwnx_rx_handle_msg(struct aic_sdio_
  }
  
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
@@ -71,11 +71,11 @@ index 5d7e6bb..478b556 100644
  
  #define MD5(x) x[0],x[1],x[2],x[3],x[4],x[5],x[6],x[7],x[8],x[9],x[10],x[11],x[12],x[13],x[14],x[15]
  #define MD5PINRT "file md5:%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\r\n"
-diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-index 86567f9..a4c760d 100644
---- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-+++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -3326,6 +3326,9 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
+Index: aic8800/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+===================================================================
+--- aic8800.orig/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ aic8800/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3601,6 +3601,9 @@ static int rwnx_cfg80211_stop_ap(struct
   * configured at firmware level.
   */
  static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
@@ -85,7 +85,7 @@ index 86567f9..a4c760d 100644
  											 struct cfg80211_chan_def *chandef)
  {
  	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
-@@ -3481,7 +3481,11 @@ static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
+@@ -3655,7 +3658,11 @@ static int rwnx_cfg80211_set_monitor_cha
  
  int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
                                               struct cfg80211_chan_def *chandef){
@@ -97,7 +97,7 @@ index 86567f9..a4c760d 100644
  }
  
  
-@@ -5281,7 +5284,11 @@ static int rwnx_cfg80211_get_channel(struct wiphy *wiphy,
+@@ -4074,7 +4081,11 @@ static int rwnx_cfg80211_get_channel(str
  
  	if (rwnx_vif->vif_index == rwnx_hw->monitor_vif) {
  		//retrieve channel from firmware
@@ -109,7 +109,7 @@ index 86567f9..a4c760d 100644
  	}
  
  	//Check if channel context is valid
-@@ -7376,8 +7386,12 @@ static void __exit rwnx_mod_exit(void)
+@@ -6460,8 +6471,12 @@ static void __exit rwnx_mod_exit(void)
  
  
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
@@ -122,11 +122,11 @@ index 86567f9..a4c760d 100644
  
  module_init(rwnx_mod_init);
  module_exit(rwnx_mod_exit);
-diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_platform.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_platform.c
-index a422ed1..3ddec73 100644
---- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_platform.c
-+++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_platform.c
-@@ -225,8 +225,12 @@ static int rwnx_plat_tl4_fw_upload(struct rwnx_plat *rwnx_plat, u8 *fw_addr,
+Index: aic8800/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_platform.c
+===================================================================
+--- aic8800.orig/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_platform.c
++++ aic8800/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_platform.c
+@@ -548,8 +548,12 @@ static int rwnx_plat_tl4_fw_upload(struc
  #endif
  
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
@@ -139,6 +139,3 @@ index a422ed1..3ddec73 100644
  
  #if 0
  /**
--- 
-2.48.1
-

--- a/debian/patches/fix-linux-6.14-build.patch
+++ b/debian/patches/fix-linux-6.14-build.patch
@@ -1,8 +1,8 @@
-diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-index 3ee11ae..77efdc8 100644
---- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-+++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -3582,6 +3582,9 @@ static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *
+Index: aic8800/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+===================================================================
+--- aic8800.orig/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ aic8800/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3763,6 +3763,9 @@ static int rwnx_cfg80211_set_tx_power(st
  static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
   struct wireless_dev *wdev,
@@ -12,11 +12,25 @@ index 3ee11ae..77efdc8 100644
  #endif
  	int *mbm)
  {
-diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-index f808d88..4b6aa20 100644
---- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-+++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -3480,6 +3480,9 @@ static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *
+Index: aic8800/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+===================================================================
+--- aic8800.orig/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ aic8800/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3845,6 +3845,9 @@ static int rwnx_cfg80211_set_tx_power(st
+ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+  struct wireless_dev *wdev,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 14, 0)
++ unsigned int link_id,
++#endif
+ #endif
+ 	int *mbm)
+ {
+Index: aic8800/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+===================================================================
+--- aic8800.orig/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
++++ aic8800/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -4513,6 +4513,9 @@ int radio_idx,
  static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
   struct wireless_dev *wdev,

--- a/debian/patches/fix-linux-6.17-build.patch
+++ b/debian/patches/fix-linux-6.17-build.patch
@@ -26,11 +26,51 @@ index ad6c52d..a61247f 100644
  {
  	struct wireless_dev *wdev = dev->ieee80211_ptr;
  	bool ret;
+diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+index 5f1e91e..b757b7e 100644
+--- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -3809,7 +3809,11 @@ void rwnx_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
+  *	have changed. The actual parameter values are available in
+  *	struct wiphy. If returning an error, no value should be changed.
+  */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+ static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
++#else
++static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, int radio_idx, u32 changed)
++#endif
+ {
+ 	return 0;
+ }
+@@ -3823,7 +3827,11 @@ static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
+  *	(as advertised by the nl80211 feature flag.)
+  */
+ static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+ 									  enum nl80211_tx_power_setting type, int mbm)
++#else
++									  int radio_idx, enum nl80211_tx_power_setting type, int mbm)
++#endif
+ {
+ 	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+ 	struct rwnx_vif *vif;
+@@ -3854,7 +3862,11 @@ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+  struct wireless_dev *wdev,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 14, 0)
++#if LINUX_VERSION_CODE < KERNEL_VERSION (6, 17, 0)
+  unsigned int link_id,
++#else
++ int radio_idx, unsigned int link_id,
++#endif
+ #endif
+ #endif
+ 	int *mbm)
 diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
-index e370a59..a5ce83b 100644
+index 4b9a0f4..5a96fff 100644
 --- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
 +++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
-@@ -1507,7 +1507,11 @@ check_len_update:
+@@ -1675,7 +1675,11 @@ check_len_update:
          hdr = (struct ieee80211_hdr *)(skb->data + msdu_offset);
          rwnx_vif = rwnx_rx_get_vif(rwnx_hw, hw_rxhdr->flags_vif_idx);
          if (rwnx_vif) {
@@ -42,7 +82,7 @@ index e370a59..a5ce83b 100644
          }
          rwnx_ipc_buf_e2a_sync_back(rwnx_hw, ipc_buf, sync_len);
          rwnx_ipc_rxbuf_repush(rwnx_hw, ipc_buf);
-@@ -1555,7 +1559,11 @@ check_len_update:
+@@ -1723,7 +1727,11 @@ check_len_update:
  
                  if (hw_rxhdr->flags_is_4addr && !rwnx_vif->use_4addr) {
                      cfg80211_rx_unexpected_4addr_frame(rwnx_vif->ndev,
@@ -54,7 +94,7 @@ index e370a59..a5ce83b 100644
                  }
              }
  
-@@ -2372,7 +2372,11 @@ check_len_update:
+@@ -2571,7 +2579,11 @@ check_len_update:
  		hdr = (struct ieee80211_hdr *)(skb->data + msdu_offset);
  		rwnx_vif = rwnx_rx_get_vif(rwnx_hw, hw_rxhdr->flags_vif_idx);
  		if (rwnx_vif) {
@@ -66,7 +106,7 @@ index e370a59..a5ce83b 100644
  		}
  		goto end;
  	}
-@@ -2651,7 +2655,11 @@ check_len_update:
+@@ -2933,7 +2945,11 @@ check_len_update:
  				if (hw_rxhdr->flags_is_4addr && !rwnx_vif->use_4addr) {
  					printk("aicwf: 4addr flag error\n");
  					rwnx_cfg80211_rx_unexpected_4addr_frame(rwnx_vif->ndev,
@@ -79,10 +119,10 @@ index e370a59..a5ce83b 100644
  			}
  
 diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-index 2a18e3d..177cd96 100644
+index 0b4455a..f330e38 100644
 --- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
 +++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -3513,7 +3513,11 @@ void rwnx_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
+@@ -3727,7 +3727,11 @@ void rwnx_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
   *	have changed. The actual parameter values are available in
   *	struct wiphy. If returning an error, no value should be changed.
   */
@@ -94,7 +134,7 @@ index 2a18e3d..177cd96 100644
  {
  	return 0;
  }
-@@ -3527,7 +3531,11 @@ static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
+@@ -3741,7 +3745,11 @@ static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
   *	(as advertised by the nl80211 feature flag.)
   */
  static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
@@ -106,7 +146,7 @@ index 2a18e3d..177cd96 100644
  {
  	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
  	struct rwnx_vif *vif;
-@@ -3558,7 +3566,11 @@ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
+@@ -3772,7 +3780,11 @@ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
   struct wireless_dev *wdev,
  #if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 14, 0)
@@ -119,10 +159,10 @@ index 2a18e3d..177cd96 100644
  #endif
  	int *mbm)
 diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
-index d5b2f63..52e8c0a 100644
+index da726dc..04964ff 100644
 --- a/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
 +++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_rx.c
-@@ -2125,7 +2125,11 @@ check_len_update:
+@@ -2396,7 +2396,11 @@ check_len_update:
  #ifdef CONFIG_GKI
  			rwnx_cfg80211_rx_spurious_frame(rwnx_vif->ndev, hdr->addr2, GFP_ATOMIC);
  #else
@@ -134,7 +174,7 @@ index d5b2f63..52e8c0a 100644
  #endif
  		}
  		goto end;
-@@ -2417,7 +2421,11 @@ check_len_update:
+@@ -2776,7 +2780,11 @@ check_len_update:
  													   sta->mac_addr, GFP_ATOMIC);
  #else
                      cfg80211_rx_unexpected_4addr_frame(rwnx_vif->ndev,
@@ -146,35 +186,11 @@ index d5b2f63..52e8c0a 100644
  #endif
  				}
  			}
-diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-index b4b8177..906c43c 100644
---- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-+++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -3495,7 +3495,11 @@ void rwnx_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
-  *	have changed. The actual parameter values are available in
-  *	struct wiphy. If returning an error, no value should be changed.
-  */
-+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
- static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
-+#else
-+static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, int radio_idx, u32 changed)
-+#endif
- {
- 	return 0;
- }
-@@ -3509,7 +3513,11 @@ static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
-  *	(as advertised by the nl80211 feature flag.)
-  */
- static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
-+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
- 									  enum nl80211_tx_power_setting type, int mbm)
-+#else
-+									  int radio_idx, enum nl80211_tx_power_setting type, int mbm)
-+#endif
- {
- 	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
- 	struct rwnx_vif *vif;
-@@ -3541,7 +3549,11 @@ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
+diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+index 06d6096..804dc2d 100644
+--- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
++++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -4514,7 +4514,11 @@ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
   struct wireless_dev *wdev,
  #if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 14, 0)

--- a/debian/patches/fix-pcie-firmware-path.patch
+++ b/debian/patches/fix-pcie-firmware-path.patch
@@ -1,8 +1,8 @@
-diff --git a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-index a787214..b739e18 100644
---- a/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-+++ b/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
-@@ -515,8 +515,8 @@ int testmode = 0;
+Index: aic8800/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+===================================================================
+--- aic8800.orig/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
++++ aic8800/src/PCIE/driver_fw/driver/aic8800/aic8800_fdrv/rwnx_main.c
+@@ -535,8 +535,8 @@ int wifi_fail = 0;
  module_param(testmode, int, 0660);
  module_param(adap_test, int, 0660);
  module_param(wifi_fail, int, 0660);

--- a/debian/patches/fix-usb-firmware-path.patch
+++ b/debian/patches/fix-usb-firmware-path.patch
@@ -1,8 +1,8 @@
 diff --git a/src/USB/driver_fw/drivers/aic8800/aic_load_fw/aicbluetooth.c b/src/USB/driver_fw/drivers/aic8800/aic_load_fw/aicbluetooth.c
-index 0270623..d557a1d 100644
+index afa29df..5944cb3 100644
 --- a/src/USB/driver_fw/drivers/aic8800/aic_load_fw/aicbluetooth.c
 +++ b/src/USB/driver_fw/drivers/aic8800/aic_load_fw/aicbluetooth.c
-@@ -169,7 +169,7 @@ enum aicbsp_cpmode_type {
+@@ -144,7 +144,7 @@ enum aicbsp_cpmode_type {
  
  #define FW_PATH_MAX 200
  #if defined(CONFIG_PLATFORM_UBUNTU)
@@ -12,10 +12,10 @@ index 0270623..d557a1d 100644
  static const char* aic_default_fw_path = "/vendor/etc/firmware";
  #endif
 diff --git a/src/USB/driver_fw/drivers/aic_btusb/aic_btusb.c b/src/USB/driver_fw/drivers/aic_btusb/aic_btusb.c
-index 1fad30f..3ea564e 100644
+index 185fcc6..18113b6 100644
 --- a/src/USB/driver_fw/drivers/aic_btusb/aic_btusb.c
 +++ b/src/USB/driver_fw/drivers/aic_btusb/aic_btusb.c
-@@ -2029,7 +2029,7 @@ struct aicbsp_info_t aicbsp_info = {
+@@ -2844,7 +2844,7 @@ struct aicbsp_info_t aicbsp_info = {
  
  char aic_fw_path[FW_PATH_MAX];
  #if (CONFIG_BLUEDROID == 0) || defined (CONFIG_PLATFORM_UBUNTU)

--- a/debian/patches/fix-vmalloc-not-include.patch
+++ b/debian/patches/fix-vmalloc-not-include.patch
@@ -1,0 +1,12 @@
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.h b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.h
+index 071f53d..6ef331f 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.h
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.h
+@@ -14,6 +14,7 @@
+ #include <linux/if_ether.h>
+ #include <linux/ieee80211.h>
+ #include <linux/semaphore.h>
++#include <linux/vmalloc.h>
+ #include "aic_bsp_driver.h"
+ 
+ #define AICBSP_SDIO_NAME                "aicbsp_sdio"

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -18,3 +18,4 @@ fix-usbc1-controller-wifi-rate-of-sun60iw2p1.patch
 fix-linux-6.17-build.patch
 fix-Lower-the-debugging-log-level.patch
 fix-linux-6.19-build.patch
+fix-vmalloc-not-include.patch


### PR DESCRIPTION
1. 适应 5.0+git20260123.5f7be68d-1 修复 patch
2. USB rwnx_main.c 引入 rwnx_cfg80211_get_tx_power，适配内核多版本内核
