### PR TITLE
usb: fix dkms cross-module symbol handoff and linux 6.17 cfg80211 get_tx_power API

### DIFF
--- a/debian/aic8800-usb-dkms.dkms
+++ b/debian/aic8800-usb-dkms.dkms
@@ -2,7 +2,8 @@ PACKAGE_VARIANT="usb"
 PACKAGE_NAME="aic8800-usb"
 PACKAGE_VERSION="#MODULE_VERSION#"
 CLEAN="make clean"
-MAKE[0]="make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build/USB/driver_fw/drivers/aic8800 &&
+MAKE[0]="make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build/USB/driver_fw/drivers/aic8800/aic_load_fw modules &&
+make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build/USB/driver_fw/drivers/aic8800/aic8800_fdrv KBUILD_EXTRA_SYMBOLS=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build/USB/driver_fw/drivers/aic8800/aic_load_fw/Module.symvers modules &&
 make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build/USB/driver_fw/drivers/aic_btusb"
 
 BUILT_MODULE_NAME[0]="aic_load_fw"

--- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -4513,6 +4513,12 @@ int radio_idx,
 static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
  struct wireless_dev *wdev,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 14, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 17, 0)
+ int radio_idx,
+#endif
+ unsigned int link_id,
+#endif
 #endif
 	int *mbm)
 {


### PR DESCRIPTION
## **Summary**
This PR addresses two USB-driver issues that can prevent successful DKMS builds and runtime Wi-Fi availability on newer kernels:

1. **DKMS cross-module symbol propagation** between `aic_load_fw` and `aic8800_fdrv`
2. **cfg80211 callback signature compatibility** for `get_tx_power` on Linux 6.14+/6.17+

---

## **Problem**
On newer kernels (observed on `6.17.x`), USB builds may fail or produce non-working runtime behavior due to:

1. **Unresolved symbols at modpost** when building `aic8800_fdrv` without symbols exported from `aic_load_fw`
2. **Function-pointer signature mismatch** in cfg80211 ops for `get_tx_power` on newer kernel APIs

Typical impact:
- DKMS build/install failures
- Driver not attaching cleanly
- Missing/unstable Wi-Fi interface after mode switch

---

## **Root Cause**
1. The DKMS USB build path did not explicitly pass `aic_load_fw/Module.symvers` into the `aic8800_fdrv` build step.
2. `rwnx_cfg80211_get_tx_power()` in the USB driver path used an older callback form and did not fully match newer cfg80211 prototypes.

---

## **Changes**
### **1) DKMS symbol handoff fix**
Updated [debian/aic8800-usb-dkms.dkms](debian/aic8800-usb-dkms.dkms) build flow to:

1. Build `aic_load_fw` first
2. Build `aic8800_fdrv` with `KBUILD_EXTRA_SYMBOLS` pointing to `aic_load_fw/Module.symvers`
3. Continue with `aic_btusb`

This ensures required exported symbols are available during `aic8800_fdrv` modpost.

### **2) Linux 6.14+/6.17+ cfg80211 compatibility**
Updated [src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c](src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/rwnx_main.c) to align `rwnx_cfg80211_get_tx_power()` with newer cfg80211 callback signatures by conditionally handling additional parameters (`link_id`, `radio_idx`) for newer kernels.

---

## **Validation**
Tested on Debian-based environment with kernel `6.17.13-2-pve`:

1. DKMS build completed successfully
2. DKMS install completed successfully
3. Modules loaded correctly (`aic_load_fw`, `aic8800_fdrv`)
4. USB adapter bound correctly after mode-switch
5. Wi-Fi interface appeared and connected
6. End-to-end connectivity confirmed (IP + DNS)

---

## **Compatibility / Risk**
1. Scope is limited to the **USB path**
2. Changes are targeted and version-gated to avoid regressions on older kernels
3. No functional behavior changes intended outside build/runtime compatibility fixes
