### PR TITLE
fix: avoid usb reboot hang after suspend

### DIFF
--- a/debian/patches/fix-usb-suspend-reboot-hang.patch
+++ b/debian/patches/fix-usb-suspend-reboot-hang.patch
@@ -1,0 +1,53 @@
+diff --git a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_usb.c b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+index b3e194b..4159742 100644
+--- a/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
++++ b/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+@@ -297,18 +297,6 @@ static void aicwf_usb_rx_complete(struct
+         aicwf_usb_rx_buf_put(usb_dev, usb_buf);
+         if(urb->status < 0){
+             AICWFDBG(LOGDEBUG, "%s urb->status:%d \r\n", __func__, urb->status);
+-
+-            if(g_rwnx_plat->wait_disconnect_cb == false){
+-                g_rwnx_plat->wait_disconnect_cb = true;
+-                if(atomic_read(&aicwf_deinit_atomic) > 0){
+-                    atomic_set(&aicwf_deinit_atomic, 0);
+-                    down(&aicwf_deinit_sem);
+-                    AICWFDBG(LOGINFO, "%s need to wait for disconnect callback \r\n", __func__);
+-                }else{
+-                    g_rwnx_plat->wait_disconnect_cb = false;
+-                }
+-            }
+-
+             return;
+         }else{
+             //schedule_work(&usb_dev->rx_urb_work);
+@@ -385,18 +373,6 @@ static void aicwf_usb_rx_complete(struct
+         aicwf_usb_rx_buf_put(usb_dev, usb_buf);
+ 		if(urb->status < 0){
+ 			AICWFDBG(LOGDEBUG, "%s urb->status:%d \r\n", __func__, urb->status);
+-
+-			if(g_rwnx_plat->wait_disconnect_cb == false){
+-				g_rwnx_plat->wait_disconnect_cb = true;
+-				if(atomic_read(&aicwf_deinit_atomic) > 0){
+-					atomic_set(&aicwf_deinit_atomic, 0);
+-					down(&aicwf_deinit_sem);
+-					AICWFDBG(LOGINFO, "%s need to wait for disconnect callback \r\n", __func__);
+-				}else{
+-					g_rwnx_plat->wait_disconnect_cb = false;
+-				}
+-			}
+-
+ 			return;
+ 		}else{
+ 			//schedule_work(&usb_dev->rx_urb_work);
+@@ -1979,10 +1955,6 @@ static void aicwf_usb_bus_stop(struct de
+     if (usb_dev->state == USB_DOWN_ST)
+         return;
+ 
+-    if(g_rwnx_plat && g_rwnx_plat->wait_disconnect_cb == true){
+-        atomic_set(&aicwf_deinit_atomic, 1);
+-        up(&aicwf_deinit_sem);
+-    }
+     aicwf_usb_state_change(usb_dev, USB_DOWN_ST);
+     //aicwf_usb_cancel_all_urbs(usb_dev);//AIDEN
+ }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -22,3 +22,4 @@ fix-linux-6.19-build.patch
 fix-vmalloc-not-include.patch
 fix-build-on-low-memory-devices.patch
 fix-linux-7.1-build.patch
+fix-usb-suspend-reboot-hang.patch


### PR DESCRIPTION
Remove the RX error-path handshake that consumes
aicwf_deinit_sem before USB disconnect starts.

Keep disconnect's existing semaphore pair, but stop aicwf_usb_rx_complete() and aicwf_usb_bus_stop() from manipulating the same semaphore during suspend and resume. This lets disconnect reach bus deinit and cancel the anchored URBs instead of blocking first.

Link:
https://vamrs.feishu.cn/sheets/IycJsx6O3hL8wctyKyecnryvn7b?sheet=fe0445&rangeId=fe0445_7t9v6cM0RY&rangeVer=1
https://vamrs.feishu.cn/sheets/PKuts3ZomhWWNKtWuW7c4Xstnph?sheet=AC3COz&rangeId=AC3COz_VXbtEjddYD&rangeVer=1
https://applink.feishu.cn/client/message/link/open?token=Ami%2F2XW%2Fg4ADaktrUsBBjLk%3D