### PR TITLE
fix aic8800 sdio firmware load issue

### DIFF
--- a/debian/patches/fix-sdio-firmware-path.patch
+++ b/debian/patches/fix-sdio-firmware-path.patch
@@ -8,7 +8,7 @@ index 8701cdc..71685f0 100644
 -CONFIG_AIC_FW_PATH = "/vendor/etc/firmware"
 -#CONFIG_AIC_FW_PATH = "/lib/firmware/aic8800D80"
 +#CONFIG_AIC_FW_PATH = "/vendor/etc/firmware"
-+CONFIG_AIC_FW_PATH = "/lib/firmware/aic8800_fw/SDIO/aic8800D80"
++CONFIG_AIC_FW_PATH = "/lib/firmware/aic8800_fw/SDIO"
  export CONFIG_AIC_FW_PATH
  ccflags-y += -DCONFIG_AIC_FW_PATH=\"$(CONFIG_AIC_FW_PATH)\"
  

--- a/debian/patches/fix-sdio-per-chip-firmware-path.patch
+++ b/debian/patches/fix-sdio-per-chip-firmware-path.patch
@@ -1,0 +1,131 @@
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic8800dc_compat.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic8800dc_compat.c
+index 64fbb01..60b9b6f 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic8800dc_compat.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic8800dc_compat.c
+@@ -5,6 +5,7 @@
+ u8 chip_sub_id = 0;
+ u8 chip_mcu_id = 0;
+ extern int testmode;
++extern void get_fw_path(char* fw_path);
+ 
+ u32 syscfg_tbl_8800dc[][2] = {
+     {0x40500010, 0x00000004},
+@@ -2482,6 +2483,7 @@ int aicwf_dpd_result_write_8800dc(void *buf, int buf_len)
+     int sum = 0, len = 0;
+     char *path = NULL;
+     struct file *fp = NULL;
++    char fw_dir[FW_PATH_MAX_LEN];
+     loff_t pos = 0;
+     mm_segment_t fs;
+ 
+@@ -2493,7 +2495,8 @@ int aicwf_dpd_result_write_8800dc(void *buf, int buf_len)
+         return -1;
+     }
+ 
+-    len = snprintf(path, FW_PATH_MAX_LEN, "%s/%s", AICBSP_FW_PATH, FW_DPDRESULT_NAME_8800DC);
++    get_fw_path(fw_dir);
++    len = snprintf(path, FW_PATH_MAX_LEN, "%s/%s", fw_dir, FW_DPDRESULT_NAME_8800DC);
+     printk("%s\n", path);
+ 
+     fp = filp_open(path, O_RDWR | O_CREAT, 0644);
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c
+index 138c8d3..194c0c2 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aic_bsp_driver.c
+@@ -34,6 +34,7 @@
+ 
+ extern int adap_test;
+ extern char aic_fw_path[FW_PATH_MAX];
++extern void get_fw_path(char* fw_path);
+ extern struct aic_sdio_dev *aicbsp_sdiodev;
+ 
+ static void cmd_dump(const struct rwnx_cmd *cmd)
+@@ -537,6 +538,7 @@ int rwnx_load_firmware(u32 **fw_buf, const char *name, struct device *device)
+ 	void *buffer = NULL;
+ 	char *path = NULL;
+ 	struct file *fp = NULL;
++	char fw_dir[AICBSP_FW_PATH_MAX];
+ 	int size = 0, len = 0;// i = 0;
+ 	ssize_t rdlen = 0;
+ 	//u32 *src = NULL, *dst = NULL;
+@@ -561,11 +563,8 @@ int rwnx_load_firmware(u32 **fw_buf, const char *name, struct device *device)
+ 		return -1;
+ 	}
+ 
+-    if(strlen(aic_fw_path) > 0){
+-        len = snprintf(path, AICBSP_FW_PATH_MAX, "%s/%s", aic_fw_path, name);
+-    }else{
+-	    len = snprintf(path, AICBSP_FW_PATH_MAX, "%s/%s", AICBSP_FW_PATH, name);
+-    }
++	get_fw_path(fw_dir);
++	len = snprintf(path, AICBSP_FW_PATH_MAX, "%s/%s", fw_dir, name);
+ 	if (len >= AICBSP_FW_PATH_MAX) {
+ 		printk("%s: %s file's path too long\n", __func__, name);
+ 		*fw_buf = NULL;
+@@ -1093,6 +1092,7 @@ int is_file_exist(char* name)
+ {
+     char *path = NULL;
+     struct file *fp = NULL;
++    char fw_dir[FW_PATH_MAX_LEN];
+     int len;
+ 
+     path = __getname();
+@@ -1101,7 +1101,8 @@ int is_file_exist(char* name)
+         return -1;
+     }
+ 
+-    len = snprintf(path, FW_PATH_MAX_LEN, "%s/%s", AICBSP_FW_PATH, name);
++    get_fw_path(fw_dir);
++    len = snprintf(path, FW_PATH_MAX_LEN, "%s/%s", fw_dir, name);
+ 
+     fp = filp_open(path, O_RDONLY, 0);
+     if (IS_ERR(fp)) {
+@@ -2237,7 +2238,7 @@ int aicbsp_get_feature(struct aicbsp_feature_t *feature, char *fw_path)
+ 	feature->fwlog_en   = aicbsp_info.fwlog_en;
+ 	feature->irqf       = aicbsp_info.irqf;
+ 	if(fw_path != NULL){
+-		sprintf(fw_path,"%s", AICBSP_FW_PATH);
++		get_fw_path(fw_path);
+ 	}
+     
+     sdio_dbg("%s, set FEATURE_SDIO_CLOCK %d MHz\n", __func__, feature->sdio_clock/1000000);
+diff --git a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.c b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.c
+index 15e5469..c873db9 100644
+--- a/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.c
++++ b/src/SDIO/driver_fw/driver/aic8800/aic8800_bsp/aicsdio.c
+@@ -2066,11 +2066,34 @@ fail:
+ 	return NULL;
+ }
+ 
++static const char* aicbsp_chip_fw_subdir(void)
++{
++	if (aicbsp_sdiodev) {
++		switch (aicbsp_sdiodev->chipid) {
++		case PRODUCT_ID_AIC8801:
++			return "/aic8800";
++		case PRODUCT_ID_AIC8800DC:
++		case PRODUCT_ID_AIC8800DW:
++			return "/aic8800DC";
++		case PRODUCT_ID_AIC8800D80:
++			return "/aic8800D80";
++		case PRODUCT_ID_AIC8800D80N:
++		case PRODUCT_ID_AIC8800D80WN:
++			return "/aic8800D80N";
++		case PRODUCT_ID_AIC8800D80X2:
++			return "/aic8800D80X2";
++		default:
++			break;
++		}
++	}
++	return "";
++}
++
+ void get_fw_path(char* fw_path){
+ 	if (strlen(aic_fw_path) > 0) {
+ 		memcpy(fw_path, aic_fw_path, strlen(aic_fw_path));
+ 	}else{
+-		memcpy(fw_path, aic_default_fw_path, strlen(aic_default_fw_path));
++		snprintf(fw_path, FW_PATH_MAX, "%s%s", aic_default_fw_path, aicbsp_chip_fw_subdir());
+ 	}
+ }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -24,3 +24,4 @@ fix-build-on-low-memory-devices.patch
 fix-linux-7.1-build.patch
 fix-usb-suspend-reboot-hang.patch
 fix-linux-7.2-build.patch
+fix-sdio-per-chip-firmware-path.patch


### PR DESCRIPTION
Closes #100
I'm trying to use sdio dkms driver on a board with aic8800 sdio wifi, but I get the following error:
```
[   85.677016] aicbsp: aicbsp_sdio_probe:1 vid:0x5449  did:0x0145
[   85.677089] aicbsp: aicbsp_sdio_probe:2 vid:0x544A  did:0x0146
[   85.677097] aicbsp: aicbsp_sdio_probe after replace:1
[   85.677103] aicbsp: aicbsp_get_feature, set FEATURE_SDIO_CLOCK 50 MHz
[   85.677108] aicbsp: aicwf_sdio_reg_init
[   85.677304] aicbsp: Set SDIO Clock 50 MHz
[   85.680293] rwnx_load_firmware :firmware path = /lib/firmware/aic8800_fw/SDIO/aic8800D80/fw_patch_table_u03.bin
[   85.712893] aicbt_patch_table_alloc fail
```
The firmware path of sdio is hard-coded to aic8800D80, while the aic8800 sdio wifi need firmware at aic8800 instead of aic8800D80.

After this pr the firmware is loaded fine:
```
[   87.594709] rwnx_load_firmware :firmware path = /lib/firmware/aic8800_fw/SDIO/aic8800/fw_patch_table_u03.bin  
[   87.597007] rwnx_load_firmware :firmware path = /lib/firmware/aic8800_fw/SDIO/aic8800/fw_adid_u03.bin  
[   87.597996] rwnx_load_firmware :firmware path = /lib/firmware/aic8800_fw/SDIO/aic8800/fw_patch_u03.bin
```